### PR TITLE
fix unable to locate gpu in tensorflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,13 @@ from gcr.io/deeplearning-platform-release/base-cu110
 
 WORKDIR /movielens
 
+ENV LD_LIBRARY_PATH /usr/local/cuda/lib64
+
 RUN git clone https://github.com/NVIDIA/NVTabular.git
 
 RUN conda env create -f=NVTabular/conda/environments/nvtabular_dev_cuda11.0.yml 
-RUN conda install -n nvtabular_dev_11.0 tensorflow==2.4.1 gcsfs
+RUN conda install -n nvtabular_dev_11.0 gcsfs
+RUN pip install tensorflow==2.4.1
 
 COPY entrypoint.sh ./
 COPY src/ src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN git clone https://github.com/NVIDIA/NVTabular.git
 
 RUN conda env create -f=NVTabular/conda/environments/nvtabular_dev_cuda11.0.yml 
 RUN conda install -n nvtabular_dev_11.0 gcsfs
-RUN pip install tensorflow==2.4.1
 
 COPY entrypoint.sh ./
 COPY src/ src/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,7 @@ conda activate nvtabular_dev_11.0
 pip install -e NVTabular/.
 pip install nvidia-pyindex
 pip install tritonclient
+pip install tensorflow==2.4.1
 
 echo "Current conda environment:" $CONDA_DEFAULT_ENV
 


### PR DESCRIPTION
1, add `export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64` to fix LD_LIBRARY_PATH in DLVM

2, conda install tensorflow doesn't install the GPU accelerated version possibly due to env conflict, have to use pip